### PR TITLE
Update bootstrap-wp.css

### DIFF
--- a/includes/css/bootstrap-wp.css
+++ b/includes/css/bootstrap-wp.css
@@ -1,7 +1,7 @@
 /*
  *
  * Here are a few needed CSS additions to integrate bootstrap truly into WordPress,
- * We kept this slim as possible. Try to avoi any overwriting if not really needed.
+ * We kept this slim as possible. Try to avoid any overwriting if not really needed.
  */
 
 


### PR DESCRIPTION
Simple spelling fix in comment. Changed "avoi" to "avoid".